### PR TITLE
Preserving the original price while displaying hour data

### DIFF
--- a/content.js
+++ b/content.js
@@ -133,8 +133,9 @@ function manipulateEdigitalHu() {
 
 // function for common price display usage, eg: '10000 Ft'
 function changeNormalPrice(item) {
+  let origText = item.innerText;
   let price = parseInt(
-    item.innerText
+    origText
       .split("Ft")
       .join("")
       .trim()
@@ -142,7 +143,7 @@ function changeNormalPrice(item) {
       .join("")
   );
   let hour = parseFloat(price / hourly).toFixed(1);
-  item.innerText = `${hour} ${hrString}`;
+  item.innerHTML = `${hour} ${hrString} <small>(${origText})</small>`;
 }
 
 // just a setTimeout wrapper


### PR DESCRIPTION
Excellent productivity/expense planning extension, I feel a huge potential here! :) 

However, I find it rather inconvenient to switch back and forth between hours and original price, so I made a small change in the way the calculations are displayed:

![screenshot_20180527_114831](https://user-images.githubusercontent.com/21174107/40584598-f7f093a8-61a3-11e8-8f90-8e11982fc00c.png)

My change is not a complete solution (eg. doesn't work on alza.hu and partially on edigital/arukereso), so I won't get mad if you don't merge it, but at least it can give you a hint where and how to improve the extension further.

(In addition, the calculation is slightly different per site and it is accomplished by a [WET solution](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), there are lots of [dead code](https://github.com/gasparrobi/Price2WorkingHours/blob/master/content.js#L87), and the documentation comments are not following any style guide (eg. [jsdoc](https://github.com/shri/JSDoc-Style-Guide)), so there are other ways of improvement as well but that's just my 2 cents :wink: :smile: )